### PR TITLE
Patch RTF decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ following placeholders which will be replaced when sending:
 - `[statement]` – replaced with a random closing statement.
 - `[image]` – replaced with embedded image HTML (if any images are selected).
 
+If the RTF content in the template contains bytes that cannot be decoded,
+the program will ignore those bytes to avoid runtime errors.
+
 ## Running
 Execute the GUI with:
 

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -36,6 +36,8 @@ pip install extract_msg pandas openpyxl pywin32
 - `[statement]` ─ 隨機結尾語
 - `[image]` ─ 內嵌圖片的 HTML（若有選擇圖片）
 
+若範本中的 RTF 內容包含無法解碼的位元組，程式會自動忽略該部分以避免錯誤。
+
 ## 執行方式
 在終端機輸入：
 

--- a/automailer_verZ.py
+++ b/automailer_verZ.py
@@ -1,4 +1,5 @@
 import extract_msg
+import RTFDE.text_extraction as rtf_te
 import pandas as pd
 import win32com.client as win32
 import os
@@ -25,6 +26,17 @@ DELAY_SEND = 10
 DELAY_DRAFT = 1
 LOG_FILE = "automailer_log.txt"
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format="%(asctime)s - %(message)s")
+
+# Patch RTFDE text extraction to ignore undecodable characters
+def _patched_decode_hex_char(item, codec):
+    if codec is None:
+        codec = 'CP1252'
+    try:
+        return item.decode(codec).encode()
+    except UnicodeDecodeError:
+        return item.decode(codec, errors='ignore').encode()
+
+rtf_te.decode_hex_char = _patched_decode_hex_char
 
 # ─────────────────────────────
 # 📂 Utils
@@ -471,7 +483,12 @@ def run_automailer(mode, recipients_path, exclusion_path, msg_template_path,
 
     msg = extract_msg.Message(msg_template_path)
     subject = msg.subject
-    html_body = msg.htmlBody.decode('utf-8', errors='ignore') if isinstance(msg.htmlBody, bytes) else msg.htmlBody
+    try:
+        raw_html_body = msg.htmlBody
+    except UnicodeDecodeError as e:
+        logger(f"HTML 解析失敗: {e}")
+        raw_html_body = None
+    html_body = raw_html_body.decode('utf-8', errors='ignore') if isinstance(raw_html_body, bytes) else (raw_html_body or '')
 
     image_html = generate_image_html(embedded_images)
 

--- a/automailer_verZ.py
+++ b/automailer_verZ.py
@@ -27,16 +27,20 @@ DELAY_DRAFT = 1
 LOG_FILE = "automailer_log.txt"
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format="%(asctime)s - %(message)s")
 
-# Patch RTFDE text extraction to ignore undecodable characters
-def _patched_decode_hex_char(item, codec):
-    if codec is None:
-        codec = 'CP1252'
-    try:
-        return item.decode(codec).encode()
-    except UnicodeDecodeError:
-        return item.decode(codec, errors='ignore').encode()
+def patch_rtfde_decode() -> None:
+    """Patch RTFDE to ignore undecodable hex characters."""
 
-rtf_te.decode_hex_char = _patched_decode_hex_char
+    def _patched_decode_hex_char(item: bytes, codec: str | None):
+        if codec is None:
+            codec = "CP1252"
+        try:
+            return item.decode(codec).encode()
+        except UnicodeDecodeError:
+            return item.decode(codec, errors="ignore").encode()
+
+    rtf_te.decode_hex_char = _patched_decode_hex_char
+
+patch_rtfde_decode()
 
 # ─────────────────────────────
 # 📂 Utils


### PR DESCRIPTION
## Summary
- patch RTFDE's decode to ignore invalid bytes
- handle htmlBody decode errors during mail generation

## Testing
- `python -m py_compile automailer_verZ.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492b453d5c832a8bb852c9950fb205