### PR TITLE
Enhance image placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ following placeholders which will be replaced when sending:
 - `[salutation]` – replaced with the value from the recipient list.
 - `[statement]` – replaced with a random closing statement.
 - `[image]` – replaced with embedded image HTML (if any images are selected).
+- `[image0]`, `[image1]`, ... – each replaced with the corresponding embedded image in
+  the order they were selected.
 
 If the RTF content in the template contains bytes that cannot be decoded,
 the program will ignore those bytes to avoid runtime errors.

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 - `[salutation]` ─ 以名單中的稱呼取代
 - `[statement]` ─ 隨機結尾語
 - `[image]` ─ 內嵌圖片的 HTML（若有選擇圖片）
+- `[image0]`, `[image1]`... ─ 依選取順序插入對應的單張圖片
 
 若範本中的 RTF 內容包含無法解碼的位元組，程式會自動忽略該部分以避免錯誤。
 

--- a/automailer_verZ.py
+++ b/automailer_verZ.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+import re
 import smtplib
 import mimetypes
 import sys
@@ -254,6 +255,29 @@ def generate_image_html(embeds):
         f'<img src="cid:{cid}" style="display:block; margin-bottom:10px;"><br>'
         for cid in embeds
     )
+
+
+def _single_image_html(cid: str) -> str:
+    """產生單一圖片的 HTML 片段"""
+    return f'<img src="cid:{cid}" style="display:block; margin-bottom:10px;"><br>'
+
+
+def replace_image_placeholders(html: str, embeds: dict[str, Path]) -> str:
+    """將 [image], [image0], [image1]... 等佔位符替換成相對應的圖片 HTML."""
+    keys = list(embeds.keys())
+
+    def repl(match: re.Match) -> str:
+        idx_str = match.group(1)
+        if idx_str == "":
+            # [image] -> 全部圖片
+            return "".join(_single_image_html(cid) for cid in keys)
+        idx = int(idx_str)
+        if 0 <= idx < len(keys):
+            return _single_image_html(keys[idx])
+        return ""
+
+    pattern = re.compile(r"\[image(\d*)\]")
+    return pattern.sub(repl, html)
 
 
 # ─────────────────────────────
@@ -806,8 +830,6 @@ def run_automailer(
         else (raw_html_body or "")
     )
 
-    image_html = generate_image_html(embedded_images)
-
     total = len(filtered)
 
     """
@@ -842,8 +864,8 @@ def run_automailer(
             body = (
                 html_body.replace("[salutation]", salutation)
                 .replace("[statement]", statement)
-                .replace("[image]", image_html)
             )
+            body = replace_image_placeholders(body, embedded_images)
 
             backend.send(
                 mode,


### PR DESCRIPTION
## Summary
- support placeholders like `[image0]`, `[image1]` etc. in message templates
- document new placeholders in both README files

## Testing
- `python -m py_compile automailer_verZ.py`


------
https://chatgpt.com/codex/tasks/task_e_68526e8c1c54832a89d5c41908a2dbc9